### PR TITLE
Ensure functions respect requested number of CPUs

### DIFF
--- a/SigProfilerExtractor/sigpro.py
+++ b/SigProfilerExtractor/sigpro.py
@@ -721,7 +721,10 @@ def sigProfilerExtractor(input_type,
             # remove signatures only if the process stability is above a thresh-hold of 0.85
             if  avgSilhouetteCoefficients> -1.0:   
                 stic = time.time() 
-                pool = mp.Pool()
+                if cpu > 0:
+                    pool = mp.Pool(processes=cpu)
+                else:
+                    pool = mp.Pool()
                 results = [pool.apply_async(ss.fit_signatures_pool, args=(genomes,processAvg,x,)) for x in range(genomes.shape[1])]
                 pooloutput = [p.get() for p in results]
                 pool.close()

--- a/SigProfilerExtractor/subroutines.py
+++ b/SigProfilerExtractor/subroutines.py
@@ -568,7 +568,8 @@ def decipher_signatures(execution_parameters, genomes=[0], i=1, totalIterations=
     
     processes=i #renamed the i as "processes"    
     processAvg, exposureAvg, processSTE,  exposureSTE, avgSilhouetteCoefficients, clusterSilhouetteCoefficients = \
-        cluster_converge_outerloop(Wall, Hall, processes, dist=dist, gpu=gpu, cluster_rand_seq=cluster_rand_seq)
+        cluster_converge_outerloop(Wall, Hall, processes, dist=dist, gpu=gpu,
+                                   cluster_rand_seq=cluster_rand_seq, n_cpu=execution_parameters["cpu"])
     reconstruction_error = round(LA.norm(genomes-np.dot(processAvg, exposureAvg), 'fro')/LA.norm(genomes, 'fro'), 2)   
     
 
@@ -806,12 +807,15 @@ def parallel_clustering(Wall, Hall, totalProcesses, iterations=50,  n_cpu=-1, di
     return result_list
 
 # To select the best clustering converge of the cluster_converge_innerloop
-def cluster_converge_outerloop(Wall, Hall, totalprocess, dist="cosine", gpu=False, cluster_rand_seq=None):
+def cluster_converge_outerloop(Wall, Hall, totalprocess, dist="cosine",
+                               gpu=False, cluster_rand_seq=None, n_cpu=-1):
     
     avgSilhouetteCoefficients = -1  # intial avgSilhouetteCoefficients 
     
     #do the parallel clustering 
-    result_list = parallel_clustering(Wall, Hall, totalprocess, iterations=50,  n_cpu=-1,  dist=dist, gpu=gpu, cluster_rand_seq=cluster_rand_seq)
+    result_list = parallel_clustering(Wall, Hall, totalprocess, iterations=50,
+                                      n_cpu=n_cpu,  dist=dist, gpu=gpu,
+                                      cluster_rand_seq=cluster_rand_seq)
     
     for i in range(50):  # using 10 iterations to get the best clustering 
         


### PR DESCRIPTION
Certain functions use all available cores for multiprocessing functions irrespective of what the user specifies when running sigProfilerExtractor. This leads to job failures under certain compute cluster environments. For example when running on SGE and requesting a set number of cores and memory, these functions attempt to use all cores on the node which can lead to the job failing as it exceeds the requested resources.

This pull request sets the number of CPUs as specified by the user for the offending functions as necessary.