### PR TITLE
Perf: Speed up CPU and GPU NMF by 30% or more

### DIFF
--- a/SigProfilerExtractor/nmf_cpu.py
+++ b/SigProfilerExtractor/nmf_cpu.py
@@ -242,18 +242,38 @@ class NMF:
 
             # Optimisations for the (common) beta=1 (KL) case.
             elif beta == 1:
-                ones = torch.ones(self._V.shape).type(self._tensor_type)
+                # The multiplicative-update denominators for KL are
+                # `ones @ H^T` and `W^T @ ones`, which reduce to row/col sums
+                # of H and W. Using sum reductions instead of matmuls against
+                # an all-ones tensor removes two matmuls per iter and the
+                # ones-tensor allocation entirely.
+                #
+                # Fast-path the `batch_size == 1` case (the 2D shim added in
+                # commit e203320 "refactoring host code to allow batch NMF" —
+                # always hit on CPU, default config on GPU) by squeezing to
+                # 2D views up front. torch.mm avoids the per-call dispatch
+                # cost that torch.bmm carries on small matrices. The 2D views
+                # share storage with the 3D self._W / self._H, so in-place
+                # updates propagate. `transpose(-2, -1)` and `dim=-1`/`-2`
+                # let the same loop body handle 2D and 3D uniformly.
+                if self._V.shape[0] == 1:
+                    V = self._V.squeeze(0)
+                    W = self._W.squeeze(0)
+                    H = self._H.squeeze(0)
+                else:
+                    V, W, H = self._V, self._W, self._H
                 for self._iter in range(self.max_iterations):
-                    ht = self.H.transpose(1, 2)
-                    numerator = (self._V / (self.W @ self.H)) @ ht
+                    WH = W @ H
+                    ratio = V / WH
+                    W.mul_(ratio @ H.transpose(-2, -1)).div_(
+                        H.sum(dim=-1, keepdim=True).transpose(-2, -1)
+                    )
 
-                    denomenator = ones @ ht
-                    self._W *= numerator / denomenator
-
-                    wt = self.W.transpose(1, 2)
-                    numerator = wt @ (self._V / (self.W @ self.H))
-                    denomenator = wt @ ones
-                    self._H *= numerator / denomenator
+                    WH = W @ H
+                    ratio = V / WH
+                    H.mul_(W.transpose(-2, -1) @ ratio).div_(
+                        W.sum(dim=-2, keepdim=True).transpose(-2, -1)
+                    )
                     if stop_iterations()[0]:
                         self._conv = stop_iterations()[1]
                         break

--- a/SigProfilerExtractor/nmf_cpu.py
+++ b/SigProfilerExtractor/nmf_cpu.py
@@ -254,17 +254,15 @@ class NMF:
                     # Unlikely on CPU; maintained for parity with GPU impl.
                     V, W, H = self._V, self._W, self._H
                 for self._iter in range(self.max_iterations):
-                    WH = W @ H
-                    ratio = V / WH
-                    W.mul_(ratio @ H.transpose(-2, -1)).div_(
-                        H.sum(dim=-1, keepdim=True).transpose(-2, -1)
-                    )
+                    ratio = V / (W @ H)
+                    numerator = ratio @ H.transpose(-2, -1)
+                    denominator = H.sum(dim=-1, keepdim=True).transpose(-2, -1)
+                    W *= numerator / denominator
 
-                    WH = W @ H
-                    ratio = V / WH
-                    H.mul_(W.transpose(-2, -1) @ ratio).div_(
-                        W.sum(dim=-2, keepdim=True).transpose(-2, -1)
-                    )
+                    ratio = V / (W @ H)
+                    numerator = W.transpose(-2, -1) @ ratio
+                    denominator = W.sum(dim=-2, keepdim=True).transpose(-2, -1)
+                    H *= numerator / denominator
                     if stop_iterations()[0]:
                         self._conv = stop_iterations()[1]
                         break

--- a/SigProfilerExtractor/nmf_cpu.py
+++ b/SigProfilerExtractor/nmf_cpu.py
@@ -33,7 +33,7 @@ class NMF:
         min_iterations=2000,
     ):
         """
-        Run non-negative matrix factorisation using GPU. Uses beta-divergence.
+        Run non-negative matrix factorisation using CPU. Uses beta-divergence.
 
         Args:
           V: Matrix to be factorised
@@ -242,25 +242,16 @@ class NMF:
 
             # Optimisations for the (common) beta=1 (KL) case.
             elif beta == 1:
-                # The multiplicative-update denominators for KL are
-                # `ones @ H^T` and `W^T @ ones`, which reduce to row/col sums
-                # of H and W. Using sum reductions instead of matmuls against
-                # an all-ones tensor removes two matmuls per iter and the
-                # ones-tensor allocation entirely.
-                #
-                # Fast-path the `batch_size == 1` case (the 2D shim added in
-                # commit e203320 "refactoring host code to allow batch NMF" —
-                # always hit on CPU, default config on GPU) by squeezing to
-                # 2D views up front. torch.mm avoids the per-call dispatch
-                # cost that torch.bmm carries on small matrices. The 2D views
-                # share storage with the 3D self._W / self._H, so in-place
-                # updates propagate. `transpose(-2, -1)` and `dim=-1`/`-2`
-                # let the same loop body handle 2D and 3D uniformly.
                 if self._V.shape[0] == 1:
+                    # For batch size == 1, the 2D torch.mm kernel avoids
+                    # some of the torch.bmm overhead, which is noticeable
+                    # at typical problem sizes. transpose(-2, -1) later
+                    # lets the same loop body handle 2D and 3D consistently.
                     V = self._V.squeeze(0)
                     W = self._W.squeeze(0)
                     H = self._H.squeeze(0)
                 else:
+                    # Unlikely on CPU; maintained for parity with GPU impl.
                     V, W, H = self._V, self._W, self._H
                 for self._iter in range(self.max_iterations):
                     WH = W @ H

--- a/SigProfilerExtractor/nmf_cpu.py
+++ b/SigProfilerExtractor/nmf_cpu.py
@@ -254,13 +254,11 @@ class NMF:
                     # Unlikely on CPU; maintained for parity with GPU impl.
                     V, W, H = self._V, self._W, self._H
                 for self._iter in range(self.max_iterations):
-                    ratio = V / (W @ H)
-                    numerator = ratio @ H.transpose(-2, -1)
+                    numerator = (V / (W @ H)) @ H.transpose(-2, -1)
                     denominator = H.sum(dim=-1, keepdim=True).transpose(-2, -1)
                     W *= numerator / denominator
 
-                    ratio = V / (W @ H)
-                    numerator = W.transpose(-2, -1) @ ratio
+                    numerator = W.transpose(-2, -1) @ (V / (W @ H))
                     denominator = W.sum(dim=-2, keepdim=True).transpose(-2, -1)
                     H *= numerator / denominator
                     if stop_iterations()[0]:

--- a/SigProfilerExtractor/nmf_gpu.py
+++ b/SigProfilerExtractor/nmf_gpu.py
@@ -240,17 +240,15 @@ class NMF:
                 else:
                     V, W, H = self._V, self._W, self._H
                 for self._iter in range(self.max_iterations):
-                    WH = W @ H
-                    ratio = V / WH
-                    W.mul_(ratio @ H.transpose(-2, -1)).div_(
-                        H.sum(dim=-1, keepdim=True).transpose(-2, -1)
-                    )
+                    ratio = V / (W @ H)
+                    numerator = ratio @ H.transpose(-2, -1)
+                    denominator = H.sum(dim=-1, keepdim=True).transpose(-2, -1)
+                    W *= numerator / denominator
 
-                    WH = W @ H
-                    ratio = V / WH
-                    H.mul_(W.transpose(-2, -1) @ ratio).div_(
-                        W.sum(dim=-2, keepdim=True).transpose(-2, -1)
-                    )
+                    ratio = V / (W @ H)
+                    numerator = W.transpose(-2, -1) @ ratio
+                    denominator = W.sum(dim=-2, keepdim=True).transpose(-2, -1)
+                    H *= numerator / denominator
                     if stop_iterations()[0]:
                         self._conv = stop_iterations()[1]
                         break

--- a/SigProfilerExtractor/nmf_gpu.py
+++ b/SigProfilerExtractor/nmf_gpu.py
@@ -229,20 +229,38 @@ class NMF:
 
             # Optimisations for the (common) beta=1 (KL) case.
             elif beta == 1:
-                ones = (
-                    torch.ones(self._V.shape).type(self._tensor_type).cuda(self._gpu_id)
-                )
+                # The multiplicative-update denominators for KL are
+                # `ones @ H^T` and `W^T @ ones`, which reduce to row/col sums
+                # of H and W. Using sum reductions instead of matmuls against
+                # an all-ones tensor removes two matmuls per iter and the
+                # ones-tensor allocation entirely.
+                #
+                # Fast-path the `batch_size == 1` case (the 2D shim added in
+                # commit e203320 "refactoring host code to allow batch NMF" —
+                # always hit on CPU, default config on GPU) by squeezing to
+                # 2D views up front. torch.mm avoids the per-call dispatch
+                # cost that torch.bmm carries on small matrices. The 2D views
+                # share storage with the 3D self._W / self._H, so in-place
+                # updates propagate. `transpose(-2, -1)` and `dim=-1`/`-2`
+                # let the same loop body handle 2D and 3D uniformly.
+                if self._V.shape[0] == 1:
+                    V = self._V.squeeze(0)
+                    W = self._W.squeeze(0)
+                    H = self._H.squeeze(0)
+                else:
+                    V, W, H = self._V, self._W, self._H
                 for self._iter in range(self.max_iterations):
-                    ht = self.H.transpose(1, 2)
-                    numerator = (self._V / (self.W @ self.H)) @ ht
+                    WH = W @ H
+                    ratio = V / WH
+                    W.mul_(ratio @ H.transpose(-2, -1)).div_(
+                        H.sum(dim=-1, keepdim=True).transpose(-2, -1)
+                    )
 
-                    denomenator = ones @ ht
-                    self._W *= numerator / denomenator
-
-                    wt = self.W.transpose(1, 2)
-                    numerator = wt @ (self._V / (self.W @ self.H))
-                    denomenator = wt @ ones
-                    self._H *= numerator / denomenator
+                    WH = W @ H
+                    ratio = V / WH
+                    H.mul_(W.transpose(-2, -1) @ ratio).div_(
+                        W.sum(dim=-2, keepdim=True).transpose(-2, -1)
+                    )
                     if stop_iterations()[0]:
                         self._conv = stop_iterations()[1]
                         break

--- a/SigProfilerExtractor/nmf_gpu.py
+++ b/SigProfilerExtractor/nmf_gpu.py
@@ -240,13 +240,11 @@ class NMF:
                 else:
                     V, W, H = self._V, self._W, self._H
                 for self._iter in range(self.max_iterations):
-                    ratio = V / (W @ H)
-                    numerator = ratio @ H.transpose(-2, -1)
+                    numerator = (V / (W @ H)) @ H.transpose(-2, -1)
                     denominator = H.sum(dim=-1, keepdim=True).transpose(-2, -1)
                     W *= numerator / denominator
 
-                    ratio = V / (W @ H)
-                    numerator = W.transpose(-2, -1) @ ratio
+                    numerator = W.transpose(-2, -1) @ (V / (W @ H))
                     denominator = W.sum(dim=-2, keepdim=True).transpose(-2, -1)
                     H *= numerator / denominator
                     if stop_iterations()[0]:

--- a/SigProfilerExtractor/nmf_gpu.py
+++ b/SigProfilerExtractor/nmf_gpu.py
@@ -229,21 +229,11 @@ class NMF:
 
             # Optimisations for the (common) beta=1 (KL) case.
             elif beta == 1:
-                # The multiplicative-update denominators for KL are
-                # `ones @ H^T` and `W^T @ ones`, which reduce to row/col sums
-                # of H and W. Using sum reductions instead of matmuls against
-                # an all-ones tensor removes two matmuls per iter and the
-                # ones-tensor allocation entirely.
-                #
-                # Fast-path the `batch_size == 1` case (the 2D shim added in
-                # commit e203320 "refactoring host code to allow batch NMF" —
-                # always hit on CPU, default config on GPU) by squeezing to
-                # 2D views up front. torch.mm avoids the per-call dispatch
-                # cost that torch.bmm carries on small matrices. The 2D views
-                # share storage with the 3D self._W / self._H, so in-place
-                # updates propagate. `transpose(-2, -1)` and `dim=-1`/`-2`
-                # let the same loop body handle 2D and 3D uniformly.
                 if self._V.shape[0] == 1:
+                    # For batch size == 1, the 2D torch.mm kernel avoids
+                    # some of the torch.bmm overhead, which is noticeable
+                    # at typical problem sizes. transpose(-2, -1) later
+                    # lets the same loop body handle 2D and 3D consistently.
                     V = self._V.squeeze(0)
                     W = self._W.squeeze(0)
                     H = self._H.squeeze(0)


### PR DESCRIPTION
Speedup comes from a few things:
- Removing the ones() matrix allocation
- Skipping the two `ones @ ht` and `wt @ ones` matmuls
- One-dimensional case, which is always true for cpu and the default for the gpu, was paying the torch batched matrix multiply kernel overhead. It's not huge, but shows up for tight iterative loops like we're doing here.

This ends up being much closer to what [scikit-learn's NMF implementation](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/decomposition/_nmf.py) does.

On my macbook, speedups look like:

```
  ┌──────┬───────┬───────────┬───────────────┬─────────┐                                                                                        
  │ rank │ iters │ master ms │ faster-nmf ms │ speedup │                                                                                        
  ├──────┼───────┼───────────┼───────────────┼─────────┤                                                                                        
  │    3 │  1000 │      55.0 │          32.8 │   1.68× │                                                                                        
  ├──────┼───────┼───────────┼───────────────┼─────────┤                                                                                        
  │    5 │  1000 │      50.1 │          27.1 │   1.85× │                                                                                        
  ├──────┼───────┼───────────┼───────────────┼─────────┤
  │    5 │  5000 │     234.9 │         129.5 │   1.81× │                                                                                        
  ├──────┼───────┼───────────┼───────────────┼─────────┤                                                                                        
  │   10 │  1000 │      54.4 │          27.8 │   1.96× │
  ├──────┼───────┼───────────┼───────────────┼─────────┤                                                                                        
  │   10 │  5000 │     261.3 │         149.8 │   1.74× │ 
  └──────┴───────┴───────────┴───────────────┴─────────┘    
```
 
running https://gist.github.com/jberg5/c2d59045f97dce18d70615993986f2d3 on my branch and master and comparing results. (full transparency: claude wrote that benchmark!). Results are equal to f32 tolerance - float reduction order is changed so I wouldn't expect bitwise identical outputs.

I also ran sigProfilerExtractor on the Nik-Zainal 2012 21-BRCA catalogue with `nmf_replicates=100`, `minimum_signatures=1, maximum_signatures=10`, and `max_nmf_iterations=100000` (all other options used the defaults). Used a gcloud c3-standard-8 (Intel Xeon Platinum 8481C, Sapphire Rapids, 4 physical cores, OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS=1).

I ran this master twice and this branch twice, ABAB, and all four runs selected the same rank (3), with identical reported stability (0.98), identical Frobenius% (5.78%), and identical sample-level  statistics. This branch was consistently 20 minutes faster (72 minutes -> 52 minutes).

**GPU Performance**: I spun up an ec2 with a T4 to do some benchmarking there and to verify correctness:

```
    ┌──────┬───────┬──────┬───────────┬───────────────┬─────────┐                                                                               
    │   M  │   N   │ rank │ master ms │ faster-nmf ms │ speedup │                                                                               
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │   96 │    21 │   5  │     405.3 │         307.5 │  1.32×  │                                                                               
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │   96 │    21 │  10  │     407.4 │         308.4 │  1.32×  │                                                                               
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │   96 │   500 │   5  │     418.8 │         314.5 │  1.33×  │                                                                               
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤
    │   96 │   500 │  10  │     417.9 │         315.4 │  1.32×  │                                                                               
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │   96 │  5000 │   5  │     419.8 │         318.4 │  1.32×  │                                                                               
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │   96 │  5000 │  10  │     420.9 │         319.1 │  1.32×  │
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │   96 │ 10000 │  10  │     555.8 │         461.8 │  1.20×  │
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │ 1536 │   500 │  10  │     447.6 │         387.6 │  1.15×  │                                                                               
    ├──────┼───────┼──────┼───────────┼───────────────┼─────────┤                                                                               
    │ 1536 │  5000 │  10  │    4130.2 │        3195.2 │  1.29×  │                                                                               
    └──────┴───────┴──────┴───────────┴───────────────┴─────────┘
```


